### PR TITLE
トップページに一旦入りCookieを設定する機能の追加

### DIFF
--- a/Sources/TitechKyomuKit/HTTP/TopPageRequest.swift
+++ b/Sources/TitechKyomuKit/HTTP/TopPageRequest.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct TopPageRequest: HTTPRequest {
+    let url: URL = URL(string: BaseURL.origin + "/Titech/Default.aspx")!
+    
+    let method: HTTPMethod = .get
+    
+    let headerFields: [String : String]? = [
+        "Connection": "keep-alive",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Encoding": "br, gzip, deflate",
+        "Accept-Language": "ja-jp"
+    ]
+    
+    let body: [String : String]? = nil
+}

--- a/Sources/TitechKyomuKit/TitechKyomu.swift
+++ b/Sources/TitechKyomuKit/TitechKyomu.swift
@@ -16,7 +16,6 @@ struct TitechKyomu {
         let html = try await httpClient.send(TopPageRequest())
         let doc = try HTML(html: html, encoding: .utf8)
         let title = doc.css("title").first?.content ?? ""
-        print(title)
         return (title.contains("学生トップ") || title.contains("Top"))
     }
     

--- a/Sources/TitechKyomuKit/TitechKyomu.swift
+++ b/Sources/TitechKyomuKit/TitechKyomu.swift
@@ -12,8 +12,12 @@ struct TitechKyomu {
         self.httpClient = HTTPClientImpl(urlSession: urlSession, userAgent: userAgent)
     }
     
-    public func loginToTop() async throws -> Bool {
+    public func fetchTopPage() async throws -> Bool {
         let html = try await httpClient.send(TopPageRequest())
+        return try await parseTopPage(html: html)
+    }
+    
+    public func parseTopPage(html: String) async throws -> Bool {
         let doc = try HTML(html: html, encoding: .utf8)
         let title = doc.css("title").first?.content ?? ""
         return (title.contains("学生トップ") || title.contains("Top"))

--- a/Sources/TitechKyomuKit/TitechKyomu.swift
+++ b/Sources/TitechKyomuKit/TitechKyomu.swift
@@ -12,6 +12,14 @@ struct TitechKyomu {
         self.httpClient = HTTPClientImpl(urlSession: urlSession, userAgent: userAgent)
     }
     
+    public func loginToTop() async throws -> Bool {
+        let html = try await httpClient.send(TopPageRequest())
+        let doc = try HTML(html: html, encoding: .utf8)
+        let title = doc.css("title").first?.content ?? ""
+        print(title)
+        return (title.contains("学生トップ") || title.contains("Top"))
+    }
+    
     public func fetchKyomuCourseData() async throws -> [KyomuCourse] {
         let html = try await httpClient.send(ReportCheckPageRequest())
         return try await parseReportCheckPage(html: html)

--- a/Tests/TitechKyomuKitTests/HTML/TopEnglish.html
+++ b/Tests/TitechKyomuKitTests/HTML/TopEnglish.html
@@ -1,0 +1,633 @@
+
+
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head id="ctl00_Head1">
+    <title>
+	Student Top   User: 20B20000 Undergraduate major in Materials Science and Engineering temmie
+</title><link href="/Titech/Content/themes/base/jquery-ui.css" type="text/css" rel="stylesheet" /><link href="/Titech/Content/bootstrap.css?20180726" type="text/css" rel="stylesheet" /><link href="/Titech/Scripts/theme/base/jquery-ui.css" type="text/css" rel="stylesheet" /><link href="/Titech/App_Themes/Default/base.css?q=1&amp;d=20220831" type="text/css" rel="stylesheet" /><link href="/Titech/App_Themes/Default/base3.css?q" type="text/css" rel="stylesheet" /><link href="/Titech/App_Themes/Default/popUp.css?20220831" type="text/css" rel="stylesheet" /><link href="/Titech/App_Themes/Default/print.css?20220831" type="text/css" rel="stylesheet" /></head>
+<body class="body">
+    <form name="aspnetForm" method="post" action="default.aspx" id="aspnetForm" class="stage stageMain">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKLTgzOTU3NzIzNWRk8nK2CfX6kC5S1zIhBvXMiMI8xvk=" />
+
+
+<script src="../Scripts/jquery-1.11.1.min.js" type="text/javascript"></script>
+<script src="../Scripts/jquery.color.js" type="text/javascript"></script>
+<script src="../Scripts/bootstrap.min.js" type="text/javascript"></script>
+<script src="../Scripts/popover.js" type="text/javascript"></script>
+<script src="../Scripts/noty/packaged/jquery.noty.packaged.min.js" type="text/javascript"></script>
+<script src="../Scripts/jquery-ui.js" type="text/javascript"></script>
+<script src="../Scripts/jquery.tbodyscroll.js" type="text/javascript"></script>
+<script src="../Scripts/JScript.js?20220831" type="text/javascript"></script>
+<script type="text/javascript">
+//<![CDATA[
+
+$(function() {
+        $('.calendar').datepicker({ dateFormat: 'yy/mm/dd' });
+    });
+$(function() {
+    setupUserAutocomplete('/Titech/Common/Service2.ashx');
+});//]]>
+</script>
+
+<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="04D80F34" />
+    
+    <a name="top"></a>
+    <table width="100%" border="0" cellpadding="0" cellspacing="0">
+        <tr id="ctl00_trHeader1" class="hideAtPrint">
+	<td id="ctl00_tdLogo" colspan="2" class="header">
+                <div class="logo" style="background-color: #0065B3">
+                    <a id="ctl00_lnkTop" href="./"><img src="../img/header_img01c_B.png" id="ctl00_imgTop" class="imgTop1" alt="国立大学法人 東京工業大学" /></a>
+                </div>
+            </td>
+</tr>
+
+        <tr id="ctl00_trHeader2" class="hideAtPrint">
+	<td id="ctl00_tdUserStatus" colspan="2" class="userStatus">
+                <table width="100%">
+                    <tr id="ctl00_trMenu">
+		<td>
+                            <span style="color: #d8d4c8">
+                                <span id="ctl00_lblID">20B20000</span><img src="../img/spacer.gif" height="3" width="3" border="0" />
+                                <span style="margin: 0px 10px">
+                                <span id="ctl00_lblInfo1">Undergraduate major in Materials Science and Engineering</span>
+                                </span>
+                                <em>
+                                    <span id="ctl00_lblName">temmie</span>
+                                </em>
+                                
+                                &nbsp;
+                                <span id="ctl00_lblName2"></span>
+                            </span>
+                        </td>
+		<td align="right" class="topButton" style="color: #777777">
+                            <span style="visibility:collapse">
+                                <input type="submit" name="ctl00$defaultButton" value="" onclick="return false;" id="defaultButton" />
+                            </span>
+                            <span id="spanManual0">
+                                <span id="spanManual">
+                                    <a href="http://www2.gakumu.titech.ac.jp/web-system/data/pdf/hinan.pdf" target="_blank">緊急時避難場所</a>
+                                    <span id="ctl00_Label1" class="lblSeparator">　|</span>
+
+                                    
+                                    <a href="http://www2.gakumu.titech.ac.jp/web-system/data/Quick_Guide.html" target="_blank">新入生向け簡易マニュアル</a>
+                                    <span class="lblSeparator"></span>
+                                    <a id="ctl00_lnkManual" href="student_manual_e.pdf" target="_blank">Manual</a>
+                                    
+                                    <span class="lblSeparator"></span>
+
+                                    <a id="ctl00_lnkFAQ" href="student_faq_e.pdf" target="_blank">FAQ</a>
+                                    <span id="ctl00_lblSeparator1" class="lblSeparator">  |  </span>
+                                </span>
+                            </span>
+
+                            <a id="ctl00_ToJapanese" href="javascript:__doPostBack(&#39;ctl00$ToJapanese&#39;,&#39;&#39;)">Japanese</a>
+                            
+                            <span id="ctl00_lblSeparator2"> | </span>
+                            <span id="ctl00_lnkLogout">
+                                <a id="ctl00_lnkLogout2" onclick="if( !confirm(&#39;Log out\n\nIf you click OK, you will logout and jump to the Tokyo Tech Portal.\n\nPress　CANCEL　if you do NOT wish to log out.&#39;) )return false;" href="../Logout.aspx">Log Out</a>
+                            </span>
+                        </td>
+	</tr>
+	
+                </table>
+            </td>
+</tr>
+
+        <tr>
+            <td id="ctl00_tdSide" valign="top" class="tdSide" width="201">
+                <div class="sideMenu">
+                    <div id="ctl00_pnlStudent">
+	
+                        <div class="menuSet clearfix">
+                            <ul>
+                                <li><span class="menuLv1">
+                                    Student</span>
+                                    <ul>
+                                        <li id="ctl00_lnkStudentTop" class="menuLv2">
+                                            <a id="ctl00_HyperLink2" href="Default.aspx">Student Top </a></li>
+                                        
+                                        
+                                        
+                                        <li id="ctl00_lnkStudentShinkokuReadonly" class="menuLv2">
+                                            <a id="ctl00_lnkStudentShinkokuReadonlyInner" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_0.aspx">Registered Course</a></li>
+                                        <li id="ctl00_lnkStudentShinkoku1" class="menuLv3">
+                                            <a id="ctl00_HyperLink37" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_0.aspx">Select from Timetable</a></li>
+                                        <li id="ctl00_lnkStudentShinkoku2" class="menuLv3">
+                                            <a id="ctl00_lnkKamokuKbn" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_1.aspx">Select from Course List</a></li>
+                                        <li id="ctl00_lnkStudentCheckResult" class="menuLv3">
+                                            <a id="ctl00_lnkCheckResult" onclick="showDialog( &#39;/Titech/Student/科目申告/PID1_3_1.aspx&#39;, 1400, 900, &#39;&#39; ); return false;" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_3_1.aspx" target="_blank">Check results<br/>Refer to the past one</a></li>
+                                        <li id="ctl00_lnkBunkeiKyouyou2Outer" class="menuLv3">
+                                            <a id="ctl00_lnkBunkeiKyouyou2" onclick="showDialog( &#39;/Titech/Common/学習申告/PID8_1.aspx&#39;, 500, 500, &#39;&#39; ); return false;" href="../Common/%E5%AD%A6%E7%BF%92%E7%94%B3%E5%91%8A/PID8_1.aspx" target="_blank">文系教養科目履修予約結果</a></li>
+                                        <li id="ctl00_lnkBunkeiKyouyouOuter" class="menuLv3">
+                                            <a id="ctl00_lnkBunkeiKyouyou" onclick="showDialog( &#39;/Titech/Common/学習申告/PID8_0.aspx&#39;, 1000, 900, &#39;&#39; ); return false;" href="../Common/%E5%AD%A6%E7%BF%92%E7%94%B3%E5%91%8A/PID8_0.aspx" target="_blank">文系教養科目申告状況</a></li>
+                                        
+                                        <li id="ctl00_lnkStudentTuika" class="menuLv2">
+                                            <a id="ctl00_lnkTuika" href="%E6%89%BF%E8%AA%8D%E7%94%B3%E8%AB%8B/PID1_7.aspx">Course Addition </a></li>
+                                        
+                                        <li id="ctl00_lnkStudentTorikesi" class="menuLv2">
+                                            <a id="ctl00_HyperLink125" href="%E6%89%BF%E8%AA%8D%E7%94%B3%E8%AB%8B/PID1_7.aspx?remove=true">Course Cancellation</a></li>
+                                        
+                                        <li id="ctl00_lnkStudentSeisekiG" class="menuLv2">
+                                            <a id="ctl00_HyperLink615" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_0.aspx">Look up Grades</a></li>
+                                        <li id="ctl00_lnkStudentSeiseki1G" class="menuLv3">
+                                            <a id="ctl00_HyperLink39" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_0.aspx">List of Ｇrades</a></li>
+                                        <li id="ctl00_lnkStudentSeisekiGPAG" class="menuLv3">
+                                            <a id="ctl00_lnkGPAg" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_7.aspx">GPA・GPT</a></li>
+                                        <li id="ctl00_lnkStudentSeiseki2G" class="menuLv3">
+                                            <a id="ctl00_HyperLink40" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_1.aspx">Grades by Semester </a></li>
+                                        
+                                        
+                                        
+                                        
+                                        
+                                        
+                                        <li id="ctl00_lnkStudentSenmonYouken" class="menuLv3">
+                                            <a id="ctl00_lnkStudentYouken" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_6.aspx">Requirements for registration of Independent Research Project and degree completion requirements</a></li>
+                                        <li id="ctl00_lnkMinitukeruChikara" class="menuLv3">
+                                            <a id="ctl00_HyperLink188" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_9.aspx">Competencies that will be developed</a></li>
+                                        
+                                        
+                                        
+
+                                        <li id="ctl00_lnkStudentSeisekiMihoukoku" class="menuLv3">
+                                            <a id="ctl00_HyperLink64" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_3.aspx">List of unreported grades</a></li>
+                                        <li id="ctl00_lnkStudentHealthInfo" class="menuLv2">
+                                            <a id="ctl00_HyperLink156" href="%E5%AD%A6%E7%94%9F%E6%83%85%E5%A0%B1/PID7_0.aspx">Look up Medical examination result</a></li>
+                                        
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="menuSet clearfix">
+                                <br />
+                                <br />
+                            <ul id="ctl00_ulSinkokuLink">
+                                <li><span class="menuLv1">
+                                    Registration Links</span>
+                                    <ul>
+                                        <li class="menuLv2">
+                                            <a id="ctl00_HyperLink23" href="https://www.titech.ac.jp/student/students/life/resources" target="_blank">Study  Guide<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                        <li class="menuLv2">
+                                            <a id="ctl00_HyperLink54" href="http://www.ocw.titech.ac.jp/" target="_blank">OCW (Refer to Syllabus)<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                        <li class="menuLv2">
+                                            <a id="ctl00_HyperLink38" href="https://www.titech.ac.jp/student/students/life/undergraduate-timetables" target="_blank">Timetable_PDF(Undergraduate Course)<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                        <li class="menuLv2">
+                                            <a id="ctl00_HyperLink53" href="https://www.titech.ac.jp/student/students/life/graduate-timetables" target="_blank">Timetable_PDF(Graduate School Course)<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                    
+</div>
+                    
+
+                    <div class="menuSet clearfix">
+
+                        
+                        
+                    
+                        
+                        <div id="ctl00_divPortfolio" class="clearfix">
+                            <br />
+                            <br />
+                            <ul>
+                                <li class="menuLv2">
+                                    <a href='https://t2schola.titech.ac.jp/?lang=en' target="_blank">T2SCHOLA<span class="glyphicon glyphicon-new-window"></span></a></li>
+                            </ul>
+                            <ul>
+                                <li class="menuLv2">
+                                    <a id="ctl00_HyperLink5" href="https://portfolio.gakumu.titech.ac.jp/" target="_blank">TokyoTechPortfolio<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                <li class="menuLv2"></li>
+                            </ul>
+                        </div>
+                        <br />
+
+                        <br />
+                        <ul id="ctl00_ulStudentUserInfo">
+                            <li class="menuLv2">
+                                <a id="ctl00_lnkStudentUserInfo" onclick="showDialog( &#39;/Titech/Student/学生情報/PID4_0.aspx?pop=true&amp;postback=ctl00_btnDummy&#39;, 1100, 900, &#39;&#39; ); return false;" href="%E5%AD%A6%E7%94%9F%E6%83%85%E5%A0%B1/PID4_0.aspx?pop=true" target="_blank">Update your data</a>
+                                
+                            </li>
+                            <li class="menuLv2">
+                                <a id="ctl00_HyperLink138" href="%E5%AD%A6%E7%94%9F%E6%83%85%E5%A0%B1/PID4_0.aspx?i=0">学生基本情報(学修)</a>
+                            </li>
+                        </ul>
+
+                        <ul id="ctl00_ulStudentKyuukou">
+                            <li class="menuLv2">
+                                <a id="ctl00_lnkStudentKyuukou" onclick="showDialog( &#39;/Titech/Student/PID5_0.aspx?mode=3&#39;, 1000, 900, &#39;&#39; ); return false;" href="PID5_0.aspx?mode=3" target="_blank">Canceled Lecture</a>
+                            </li>
+                        </ul>
+                        
+                        <ul>
+                            <li id="ctl00_Li12" class="menuLv2">
+                                <a id="ctl00_HyperLink15" href="../Common/%E3%82%AD%E3%83%A3%E3%83%AA%E3%82%A2/PID_career_top.aspx">Career Advice</a></li>
+                            
+                        </ul>
+                        
+                        <ul>
+                            <li id="ctl00_Li17" class="menuLv2">
+                                <a id="ctl00_HyperLink28" href="../Common/%E3%82%AD%E3%83%A3%E3%83%AA%E3%82%A2/PID_career_report_list.aspx">My Job-Seeking Story</a></li>
+                        </ul>
+                        <ul id="ctl00_ul1">
+                            <li class="menuLv2">
+                                <a id="ctl00_HyperLink45" href="../Common/FacilityReservation/Top.aspx">Reserving facilities</a></li>
+                        </ul>
+                        <ul id="ctl00_ulStudentBikeRegistration">
+                            <li class="menuLv2">
+                                <a id="ctl00_lnkStudentBikeRegistration" onclick="showDialog( &#39;/Titech/Student/PID6_0.aspx&#39;, 1380, 950, &#39;&#39; ); return false;" href="PID6_0.aspx" target="_blank">Bicycle,Motorbike Registration</a>
+                            </li>
+                        </ul>
+
+                        
+                        <ul>
+                            <li class="menuLv2">
+                                <a id="ctl00_lnkInquiry" onclick="showDialog( &#39;/Titech/Inquiry.aspx&#39;, 750, 800, &#39;&#39; ); return false;" href="../Inquiry.aspx" target="_blank">Inquiry</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </td>
+
+            <td valign="top" width="90%" id="MainContents">
+                <div id="ctl00_divMainContents" class="mainContents">
+                    
+                    <div id="ctl00_Div1" class="alertMsg" style="text-align: center; margin-top: -10px; margin-bottom: 8px">
+                    </div>
+                    <div id="ctl00_lblStatusAlert" class="alertMsg" style="text-align: center; margin-top: -10px; margin-bottom: 8px">
+                    </div>
+                    <span id="ctl00_lblMessage" class="alertMsg"></span>
+                    <noscript><div class="alertMsg">JavaScriptが有効ではありません。<BR>教務WebシステムはJavaScript対応のブラウザで閲覧してください。</div></noscript>
+                    
+    <style type="text/css">
+        .torikesiPDF {
+            color: #ff4400;
+        }
+    </style>
+
+    <script type="text/javascript">
+
+        $(document).ready(function () {
+            setTimeout(function () {
+                showNewsList();
+            }, 500);
+            setTimeout(function () {
+                showEnqueteList();
+            }, 500);
+
+            
+            setTimeout(function () {
+                showTEList();
+            }, 500);
+            
+
+            $(document).on("click", "a.lnkInput", function () {
+                var jwc = $(this).attr("jwc");
+                showTEInput(query = jwc ? "jwc=" + jwc : "aid=" + $(this).attr("aId"));
+                return false;
+            });
+            
+            
+            $(".spanKyuko").hide();
+            $.ajax({
+                url: "../Common/Service3.ashx?type=kyuko&gno=20B20000",
+                dataType: "text",
+                cache: false,
+                success: function (data) { 
+                    if (data) {
+                        console.log(data);
+                        $("#lblKyuukou").html(data);
+                        $(".spanKyuko").show();
+                    }
+                },
+                error: function () {
+                    $("#lblKyuukou").html("");
+                }
+            });
+            
+        });
+
+        function showNewsList() {
+            $.ajax({
+                url: "../Common/お知らせ/NewsList.aspx",
+                dataType: "text",
+                cache: false,
+                success: function (data) {
+                    if (data) {
+                        $("#divOsirase").html($(data).find("#divOsiraseI").eq(0));
+                        
+                        var id = $("#hdnOsiraseID2").val();
+                        if(id)
+                        {
+                            location.href = "../Common/お知らせ/NewsPopup.aspx?pop=false&id=" + id;
+                            return;
+                        }
+
+                        if($("#hdnOsiraseID").val()) {
+                            setTimeout(function(){ $("#pnlNews").dialog({
+                                autoOpen: false,
+                                modal: true,
+                                minWidth: 800
+                            }).dialog( "open" ); },50);
+                        }
+                        //var sc = $(data).find("script");
+                        //eval(sc.eq(sc.length - 1).html());
+                        //eval("setTimeout(function(){ $('#pnlNews').dialog({    autoOpen: false,    modal: true,    minWidth: 800}).dialog( 'open' ); },50);");
+                        //eval("setTimeout(function() { alert(''); }, 50);");
+                    }
+                },
+                error: function () {
+                    //$("#divTE").hide();
+                    $("#divOsirase").html("");
+                }
+            });
+        }
+
+        function showEnqueteList() {
+            $.ajax({
+                url: "../Common/アンケート/EnqueteList.aspx",
+                dataType: "text",
+                cache: false,
+                success: function (data) {
+                    if (data) {
+                        $("#divEnquete").html($(data).find("#divEnqueteI").eq(0));
+                        
+                        var url = $("#hdnEnqueteUrl").val();
+                        if(url)
+                        {
+                            location.href = url;
+                            return;
+                        }
+                    }
+                },
+                error: function () {
+                    $("#divEnquete").html("");
+                }
+            });
+        }
+
+        function showTEInput(query) {
+            if (!query) {
+                query = "jwc=" + $("#drpJwc").val();
+            }
+            showDialog("../Common/旅費/PID_travel_expenses_input.aspx?" + query, 1200, 1000);
+        }
+
+        function showTEList() {
+            $.ajax({
+                url: "旅費/PID_travel_expenses_top.aspx",
+                dataType: "text",
+                cache: false,
+                success: function (data) { 
+                    if (data) {
+                        $("#divTE").html($(data).find("#div0").eq(0));
+                    }
+                },
+                error: function () {
+                    //$("#divTE").hide();
+                    $("#divTE").html("");
+                }
+            });
+        }
+    </script>
+
+    
+    
+    <div>
+        <div style="float: left">
+            <h3>
+                News</h3>
+            
+            <div style="margin-bottom: 30px; min-height: 30px;" id="divOsirase">
+                <img src="../img/loading2.gif" border="0" />
+            </div>
+        </div>
+        <div style="float: left; padding-left: 15px">
+            
+<style type="text/css">
+ul.mainte li
+{
+    margin-top: 3px;
+    border-bottom: dotted 1px #bbb;
+    font-weight: normal;
+}
+</style>
+
+<h3>Maintenance Info</h3>
+<div style="padding:5px;width:270px;background-color: ghostWhite;border:dotted 1px #569;">
+    <span class="comment">The system will be unavailable during this time. </span>
+    <div><!-- 直近3つのメンテナンス予定を表示する。 -->
+    <ul style="padding:3px;list-style:none;" class="mainte">
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T1"><b>Fri., Sep. 2, 2022, 4:00 AM</b> ～ <b>8:50 AM</b></span></li>
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T2"><b>Tue., Sep. 6, 2022, 4:00 AM</b> ～ <b>8:50 AM</b></span></li>
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T3"><b>Fri., Sep. 9, 2022, 4:00 AM</b> ～ <b>8:50 AM</b></span></li>
+    </ul>
+    </div>
+    <!-- メンテナンス情報フリーコメント -->
+    <div style="border:solid 1px #568;background-color:White;padding:5px;margin-top:3px;">
+    <textarea name="ctl00$ContentPlaceHolder1$ucMpre$txtMntFree" rows="2" cols="20" readonly="readonly" id="ctl00_ContentPlaceHolder1_ucMpre_txtMntFree">
+Due to scheduled maintenance, the Web System will be unavailable every Tuesday and Friday,  from 4:00 AM to 8:50 AM.</textarea>
+    </div>
+</div>
+        </div>
+        <br style="clear: both" />
+    </div>
+    <div>
+        
+        <div id="divEnquete">
+            <h3>
+        アンケート</h3>
+            <div style="padding-bottom: 20px"><img src="../img/loading2.gif" border="0" /></div>
+        </div>
+    </div>
+    
+    
+    <h3>旅費支援申請
+    </h3>
+    <div style="margin-bottom: 30px; min-height: 30px;" id="divTE">
+        <img src="../img/loading2.gif" border="0" />
+    </div>
+    
+
+    <div></div>
+    <div class="linkBoxLeft">
+        
+        <div id="ctl00_ContentPlaceHolder1_divShinkoku">
+            <h3 id="ctl00_ContentPlaceHolder1_divShinkokuH3">
+                
+                Registered Course</h3>
+            
+            <ul style="margin-bottom: 20px">
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentShinkoku1">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink37" href="../Student/%e7%a7%91%e7%9b%ae%e7%94%b3%e5%91%8a/PID1_0.aspx">Select from Timetable</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentShinkoku2">
+                    <a id="ctl00_ContentPlaceHolder1_lnkKamokuKbn" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_1.aspx">Select from Course List</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentCheckResult">
+                    <a id="ctl00_ContentPlaceHolder1_lnkCheckResult" onclick="showDialog( &#39;/Titech/Student/科目申告/PID1_3_1.aspx&#39;, 1400, 900, &#39;&#39; ); return false;" href="../Student/%e7%a7%91%e7%9b%ae%e7%94%b3%e5%91%8a/PID1_3_1.aspx" target="_blank">Check results
+Refer to the past one</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkBunkeiKyouyou2Outer">
+                    <a id="ctl00_ContentPlaceHolder1_lnkBunkeiKyouyou2" onclick="showDialog( &#39;/Titech/Common/学習申告/PID8_1.aspx&#39;, 500, 500, &#39;&#39; ); return false;" href="../Common/%e5%ad%a6%e7%bf%92%e7%94%b3%e5%91%8a/PID8_1.aspx" target="_blank">文系教養科目履修予約結果</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkBunkeiKyouyouOuter">
+                    <a id="ctl00_ContentPlaceHolder1_lnkBunkeiKyouyou" onclick="showDialog( &#39;/Titech/Common/学習申告/PID8_0.aspx&#39;, 1000, 800, &#39;&#39; ); return false;" href="../Common/%e5%ad%a6%e7%bf%92%e7%94%b3%e5%91%8a/PID8_0.aspx" target="_blank">文系教養科目申告状況</a></li>
+            </ul>
+        </div>
+        
+        <div id="ctl00_ContentPlaceHolder1_divTeisei">
+            <h3>
+                Course Addition/Cancellation</h3>
+            <ul style="margin-bottom: 20px">
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentTuika">
+                    <a id="ctl00_ContentPlaceHolder1_lnkTeisei" href="../Student/%e6%89%bf%e8%aa%8d%e7%94%b3%e8%ab%8b/PID1_7.aspx">Course Addition </a></li>
+                
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentTorikesi">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink4" href="../Student/%e6%89%bf%e8%aa%8d%e7%94%b3%e8%ab%8b/PID1_7.aspx?remove=true">Course Cancellation</a></li>
+            </ul>
+        </div>
+        <div id="ctl00_ContentPlaceHolder1_divSinkokuLink">
+            <h3>
+                Registration Links</h3>
+            <ul style="line-height: 200%;">
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink23" href="http://www.titech.ac.jp/enrolled/life/resources/index.html" target="_blank">Study  Guide</a></li>
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink54" href="http://www.ocw.titech.ac.jp/" target="_blank">OCW (Refer to Syllabus)</a></li>
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink38" href="http://www.titech.ac.jp/enrolled/life/undergraduate_timetables.html" target="_blank">Timetable_PDF(Undergraduate Course)</a></li>
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink53" href="http://www.titech.ac.jp/enrolled/life/graduate_timetables.html" target="_blank">Timetable_PDF(Graduate School Course)</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="linkBoxRight">
+        <div id="ctl00_ContentPlaceHolder1_divKyuukou">
+            <h3>
+                各種情報</h3>
+            <ul style="margin-bottom: 20px">
+                
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_lnkKyuukou" onclick="showDialog( &#39;/Titech/Student/PID5_0.aspx?mode=3&#39;, 1000, 900, &#39;&#39; ); return false;" href="../Student/PID5_0.aspx?mode=3" target="_blank">Canceled Lecture</a>
+                    <span id="ctl00_ContentPlaceHolder1_spanKyuukouCount" class="spanKyuko">&nbsp;&nbsp;&nbsp;&nbsp;今週の休講：
+                        <span id="lblKyuukou"><b><font size="3"></font></b></span></span> </li>
+                
+                <li>
+                    <a href="http://www.titech.ac.jp/staff/rooms/procedures.html" target="_blank">手続書類一覧</a>
+                </li>
+                <li>
+                    <a href="http://www.titech.ac.jp/registrar/index.html" target="_blank">Student Affairs Division</a>
+                </li>
+                <li>
+                    <a href="http://www.titech.ac.jp/enrolled/board/index.html" target="_blank">学務部掲示物情報</a>
+                </li>
+            </ul>
+        </div>
+        <div id="ctl00_ContentPlaceHolder1_divSeiseki">
+            <h3>
+                Look up Grades</h3>
+            <ul>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSeiseki1G">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink39" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_0.aspx">List of Ｇrades</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSeisekiGPAG">
+                    <a id="ctl00_ContentPlaceHolder1_lnkGPA" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_7.aspx">GPA・GPT</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSeiseki2G">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink40" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_1.aspx">Grades by Semester </a></li>
+                
+                
+                
+                
+                
+                
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSenmonYouken">
+                    <a id="ctl00_ContentPlaceHolder1_lnkYouken" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_6.aspx">Requirements for registration of Independent Research Project and degree completion requirements</a>
+                </li>
+                <li id="ctl00_ContentPlaceHolder1_lnkMinitukeruChikara">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink188" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_9.aspx">Competencies that will be developed</a></li>
+                
+                
+                
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSeisekiMihoukoku">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink2" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_3.aspx">List of unreported grades</a></li>
+            </ul>
+            <br />
+            
+            
+        </div>
+    </div>
+    <br />
+    <div style="clear: both">
+        <br />
+        <br />
+        <br />
+        <br />
+        
+        
+        
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        
+    </div>
+
+    
+                </div>
+                <span style="visibility: hidden;">
+                    <input type="submit" name="ctl00$btnDummy" value="" id="ctl00_btnDummy" />
+                </span>
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" valign="top" bgcolor="#000000">
+                <div class="footer" style="clear: both;">
+                    
+                    <span style="color: #005396;">
+                        003</span>
+                    <span style="color: #005396; margin-left: 20px">
+                        Build:8/31/2022 9:02:39 AM</span>
+                </div>
+            </td>
+        </tr>
+    </table>
+        
+    <style type="text/css">
+        #defaultButton {
+            height: 16px;
+        }
+        #divMenu ul:hover
+        {
+            /*background-color: rgba(255,255,255,0.5);*/
+            background-color: rgba(0,0,0,0.05);
+        }
+
+        #pnlMenu {
+            position: fixed;
+            top: 10px;
+        }
+
+        .sideMenu .glyphicon {
+            margin-left: 8px;
+            opacity: 0.8;
+        }
+        
+        
+    </style>
+
+    
+
+        
+    <div class="modal fade" id="modal-menu" tabindex="-1">
+        <div class="modal-dialog" style="width:initial; margin: 5px;">
+            <!-- モーダルのコンテンツ modal fade modalCenter-->
+            <div class="modal-content" style="position: fixed;  overflow-y: scroll; ">
+                <!-- モーダルのボディ -->
+                <div class="modal-body tableSet01" id="menu2" style="padding: 14px">
+                </div>
+                <div id="menu3" style="margin: 4px 14px 24px 14px;    padding: 5px;    border: dotted 1px #060691;    background-color: #f5f5f5;    line-height: 160%;">
+                </div>
+            </div>
+        </div>
+    </div>
+    </form>
+    <script type="text/javascript">
+        
+    </script>
+</body>
+</html>

--- a/Tests/TitechKyomuKitTests/HTML/TopJapanese.html
+++ b/Tests/TitechKyomuKitTests/HTML/TopJapanese.html
@@ -1,0 +1,634 @@
+
+
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head id="ctl00_Head1">
+    <title>
+	学生トップ  User: 20B20000 材料系 temmie
+</title><link href="/Titech/Content/themes/base/jquery-ui.css" type="text/css" rel="stylesheet" /><link href="/Titech/Content/bootstrap.css?20180726" type="text/css" rel="stylesheet" /><link href="/Titech/Scripts/theme/base/jquery-ui.css" type="text/css" rel="stylesheet" /><link href="/Titech/App_Themes/Default/base.css?q=1&amp;d=20220831" type="text/css" rel="stylesheet" /><link href="/Titech/App_Themes/Default/base3.css?q" type="text/css" rel="stylesheet" /><link href="/Titech/App_Themes/Default/popUp.css?20220831" type="text/css" rel="stylesheet" /><link href="/Titech/App_Themes/Default/print.css?20220831" type="text/css" rel="stylesheet" /></head>
+<body class="body">
+    <form name="aspnetForm" method="post" action="default.aspx" id="aspnetForm" class="stage stageMain">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKLTgzOTU3NzIzNWRk8nK2CfX6kC5S1zIhBvXMiMI8xvk=" />
+
+
+<script src="../Scripts/jquery-1.11.1.min.js" type="text/javascript"></script>
+<script src="../Scripts/jquery.color.js" type="text/javascript"></script>
+<script src="../Scripts/bootstrap.min.js" type="text/javascript"></script>
+<script src="../Scripts/popover.js" type="text/javascript"></script>
+<script src="../Scripts/noty/packaged/jquery.noty.packaged.min.js" type="text/javascript"></script>
+<script src="../Scripts/jquery-ui.js" type="text/javascript"></script>
+<script src="../Scripts/jquery.tbodyscroll.js" type="text/javascript"></script>
+<script src="../Scripts/JScript.js?20220831" type="text/javascript"></script>
+<script src="../Scripts/jquery.ui.datepicker-ja.js" type="text/javascript"></script>
+<script type="text/javascript">
+//<![CDATA[
+
+$(function() {
+        $('.calendar').datepicker({ dateFormat: 'yy/mm/dd' });
+    });
+$(function() {
+    setupUserAutocomplete('/Titech/Common/Service2.ashx');
+});//]]>
+</script>
+
+<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="04D80F34" />
+    
+    <a name="top"></a>
+    <table width="100%" border="0" cellpadding="0" cellspacing="0">
+        <tr id="ctl00_trHeader1" class="hideAtPrint">
+	<td id="ctl00_tdLogo" colspan="2" class="header">
+                <div class="logo" style="background-color: #0065B3">
+                    <a id="ctl00_lnkTop" href="./"><img src="../img/header_img01c_B.png" id="ctl00_imgTop" class="imgTop1" alt="国立大学法人 東京工業大学" /></a>
+                </div>
+            </td>
+</tr>
+
+        <tr id="ctl00_trHeader2" class="hideAtPrint">
+	<td id="ctl00_tdUserStatus" colspan="2" class="userStatus">
+                <table width="100%">
+                    <tr id="ctl00_trMenu">
+		<td>
+                            <span style="color: #d8d4c8">
+                                <span id="ctl00_lblID">20B20000</span><img src="../img/spacer.gif" height="3" width="3" border="0" />
+                                <span style="margin: 0px 10px">
+                                <span id="ctl00_lblInfo1">材料系</span>
+                                </span>
+                                <em>
+                                    <span id="ctl00_lblName">temmie</span>
+                                </em>
+                                さん
+                                &nbsp;
+                                <span id="ctl00_lblName2"></span>
+                            </span>
+                        </td>
+		<td align="right" class="topButton" style="color: #777777">
+                            <span style="visibility:collapse">
+                                <input type="submit" name="ctl00$defaultButton" value="" onclick="return false;" id="defaultButton" />
+                            </span>
+                            <span id="spanManual0">
+                                <span id="spanManual">
+                                    <a href="http://www2.gakumu.titech.ac.jp/web-system/data/pdf/hinan.pdf" target="_blank">緊急時避難場所</a>
+                                    <span id="ctl00_Label1" class="lblSeparator">　|</span>
+
+                                    
+                                    <a href="http://www2.gakumu.titech.ac.jp/web-system/data/Quick_Guide.html" target="_blank">新入生向け簡易マニュアル</a>
+                                    <span class="lblSeparator"></span>
+                                    <a id="ctl00_lnkManual" href="student_manual_j.pdf" target="_blank">マニュアル</a>
+                                    
+                                    <span class="lblSeparator"></span>
+
+                                    <a id="ctl00_lnkFAQ" href="student_faq_j.pdf" target="_blank">FAQ</a>
+                                    <span id="ctl00_lblSeparator1" class="lblSeparator">  |  </span>
+                                </span>
+                            </span>
+
+                            
+                            <a id="ctl00_ToEnglish" href="javascript:__doPostBack(&#39;ctl00$ToEnglish&#39;,&#39;&#39;)">English</a>
+                            <span id="ctl00_lblSeparator2"> | </span>
+                            <span id="ctl00_lnkLogout">
+                                <a id="ctl00_lnkLogout2" onclick="if( !confirm(&#39;ログアウトをします。\n\nOKをクリックするとログアウトが実行され\n学内ポータルへ遷移します。\n中断する場合は「キャンセル」をクリックしてください&#39;) )return false;" href="../Logout.aspx">ログアウト</a>
+                            </span>
+                        </td>
+	</tr>
+	
+                </table>
+            </td>
+</tr>
+
+        <tr>
+            <td id="ctl00_tdSide" valign="top" class="tdSide" width="201">
+                <div class="sideMenu">
+                    <div id="ctl00_pnlStudent">
+	
+                        <div class="menuSet clearfix">
+                            <ul>
+                                <li><span class="menuLv1">
+                                    学生</span>
+                                    <ul>
+                                        <li id="ctl00_lnkStudentTop" class="menuLv2">
+                                            <a id="ctl00_HyperLink2" href="Default.aspx">学生トップ</a></li>
+                                        
+                                        
+                                        
+                                        <li id="ctl00_lnkStudentShinkokuReadonly" class="menuLv2">
+                                            <a id="ctl00_lnkStudentShinkokuReadonlyInner" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_0.aspx">申告科目の参照</a></li>
+                                        <li id="ctl00_lnkStudentShinkoku1" class="menuLv3">
+                                            <a id="ctl00_HyperLink37" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_0.aspx">時間割から</a></li>
+                                        <li id="ctl00_lnkStudentShinkoku2" class="menuLv3">
+                                            <a id="ctl00_lnkKamokuKbn" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_1.aspx">科目から</a></li>
+                                        <li id="ctl00_lnkStudentCheckResult" class="menuLv3">
+                                            <a id="ctl00_lnkCheckResult" onclick="showDialog( &#39;/Titech/Student/科目申告/PID1_3_1.aspx&#39;, 1400, 900, &#39;&#39; ); return false;" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_3_1.aspx" target="_blank">申告チェック結果/<br/>過去分の参照</a></li>
+                                        <li id="ctl00_lnkBunkeiKyouyou2Outer" class="menuLv3">
+                                            <a id="ctl00_lnkBunkeiKyouyou2" onclick="showDialog( &#39;/Titech/Common/学習申告/PID8_1.aspx&#39;, 500, 500, &#39;&#39; ); return false;" href="../Common/%E5%AD%A6%E7%BF%92%E7%94%B3%E5%91%8A/PID8_1.aspx" target="_blank">文系教養科目履修予約結果</a></li>
+                                        <li id="ctl00_lnkBunkeiKyouyouOuter" class="menuLv3">
+                                            <a id="ctl00_lnkBunkeiKyouyou" onclick="showDialog( &#39;/Titech/Common/学習申告/PID8_0.aspx&#39;, 1000, 900, &#39;&#39; ); return false;" href="../Common/%E5%AD%A6%E7%BF%92%E7%94%B3%E5%91%8A/PID8_0.aspx" target="_blank">文系教養科目申告状況</a></li>
+                                        
+                                        <li id="ctl00_lnkStudentTuika" class="menuLv2">
+                                            <a id="ctl00_lnkTuika" href="%E6%89%BF%E8%AA%8D%E7%94%B3%E8%AB%8B/PID1_7.aspx">追加申告</a></li>
+                                        
+                                        <li id="ctl00_lnkStudentTorikesi" class="menuLv2">
+                                            <a id="ctl00_HyperLink125" href="%E6%89%BF%E8%AA%8D%E7%94%B3%E8%AB%8B/PID1_7.aspx?remove=true">申告取消</a></li>
+                                        
+                                        <li id="ctl00_lnkStudentSeisekiG" class="menuLv2">
+                                            <a id="ctl00_HyperLink615" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_0.aspx">成績閲覧</a></li>
+                                        <li id="ctl00_lnkStudentSeiseki1G" class="menuLv3">
+                                            <a id="ctl00_HyperLink39" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_0.aspx">成績一覧</a></li>
+                                        <li id="ctl00_lnkStudentSeisekiGPAG" class="menuLv3">
+                                            <a id="ctl00_lnkGPAg" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_7.aspx">GPA・GPT</a></li>
+                                        <li id="ctl00_lnkStudentSeiseki2G" class="menuLv3">
+                                            <a id="ctl00_HyperLink40" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_1.aspx">修得時期別成績一覧</a></li>
+                                        
+                                        
+                                        
+                                        
+                                        
+                                        
+                                        <li id="ctl00_lnkStudentSenmonYouken" class="menuLv3">
+                                            <a id="ctl00_lnkStudentYouken" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_6.aspx">学士特定課題研究申請・卒業要件</a></li>
+                                        <li id="ctl00_lnkMinitukeruChikara" class="menuLv3">
+                                            <a id="ctl00_HyperLink188" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_9.aspx">学生が身に付ける力</a></li>
+                                        
+                                        
+                                        
+
+                                        <li id="ctl00_lnkStudentSeisekiMihoukoku" class="menuLv3">
+                                            <a id="ctl00_HyperLink64" href="%E6%88%90%E7%B8%BE%E9%96%B2%E8%A6%A7/PID2_3.aspx">成績未報告科目一覧</a></li>
+                                        <li id="ctl00_lnkStudentHealthInfo" class="menuLv2">
+                                            <a id="ctl00_HyperLink156" href="%E5%AD%A6%E7%94%9F%E6%83%85%E5%A0%B1/PID7_0.aspx">健康診断結果閲覧</a></li>
+                                        
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="menuSet clearfix">
+                                <br />
+                                <br />
+                            <ul id="ctl00_ulSinkokuLink">
+                                <li><span class="menuLv1">
+                                    申告関係リンク</span>
+                                    <ul>
+                                        <li class="menuLv2">
+                                            <a id="ctl00_HyperLink23" href="https://www.titech.ac.jp/student/students/life/resources" target="_blank">学修案内<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                        <li class="menuLv2">
+                                            <a id="ctl00_HyperLink54" href="http://www.ocw.titech.ac.jp/" target="_blank">ＯＣＷ（シラバス参照）<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                        <li class="menuLv2">
+                                            <a id="ctl00_HyperLink38" href="https://www.titech.ac.jp/student/students/life/undergraduate-timetables" target="_blank">時間割PDF(学士課程)<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                        <li class="menuLv2">
+                                            <a id="ctl00_HyperLink53" href="https://www.titech.ac.jp/student/students/life/graduate-timetables" target="_blank">時間割PDF(大学院)<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                    
+</div>
+                    
+
+                    <div class="menuSet clearfix">
+
+                        
+                        
+                    
+                        
+                        <div id="ctl00_divPortfolio" class="clearfix">
+                            <br />
+                            <br />
+                            <ul>
+                                <li class="menuLv2">
+                                    <a href='https://t2schola.titech.ac.jp/' target="_blank">T2SCHOLA<span class="glyphicon glyphicon-new-window"></span></a></li>
+                            </ul>
+                            <ul>
+                                <li class="menuLv2">
+                                    <a id="ctl00_HyperLink5" href="https://portfolio.gakumu.titech.ac.jp/" target="_blank">学修ポートフォリオ<span class="glyphicon glyphicon-new-window"></span></a></li>
+                                <li class="menuLv2"></li>
+                            </ul>
+                        </div>
+                        <br />
+
+                        <br />
+                        <ul id="ctl00_ulStudentUserInfo">
+                            <li class="menuLv2">
+                                <a id="ctl00_lnkStudentUserInfo" onclick="showDialog( &#39;/Titech/Student/学生情報/PID4_0.aspx?pop=true&amp;postback=ctl00_btnDummy&#39;, 1100, 900, &#39;&#39; ); return false;" href="%E5%AD%A6%E7%94%9F%E6%83%85%E5%A0%B1/PID4_0.aspx?pop=true" target="_blank">学生基本情報登録</a>
+                                
+                            </li>
+                            <li class="menuLv2">
+                                <a id="ctl00_HyperLink138" href="%E5%AD%A6%E7%94%9F%E6%83%85%E5%A0%B1/PID4_0.aspx?i=0">学生基本情報(学修)</a>
+                            </li>
+                        </ul>
+
+                        <ul id="ctl00_ulStudentKyuukou">
+                            <li class="menuLv2">
+                                <a id="ctl00_lnkStudentKyuukou" onclick="showDialog( &#39;/Titech/Student/PID5_0.aspx?mode=3&#39;, 1000, 900, &#39;&#39; ); return false;" href="PID5_0.aspx?mode=3" target="_blank">休講一覧</a>
+                            </li>
+                        </ul>
+                        
+                        <ul>
+                            <li id="ctl00_Li12" class="menuLv2">
+                                <a id="ctl00_HyperLink15" href="../Common/%E3%82%AD%E3%83%A3%E3%83%AA%E3%82%A2/PID_career_top.aspx">キャリア相談</a></li>
+                            
+                        </ul>
+                        
+                        <ul>
+                            <li id="ctl00_Li17" class="menuLv2">
+                                <a id="ctl00_HyperLink28" href="../Common/%E3%82%AD%E3%83%A3%E3%83%AA%E3%82%A2/PID_career_report_list.aspx">就職体験記</a></li>
+                        </ul>
+                        <ul id="ctl00_ul1">
+                            <li class="menuLv2">
+                                <a id="ctl00_HyperLink45" href="../Common/FacilityReservation/Top.aspx">施設予約</a></li>
+                        </ul>
+                        <ul id="ctl00_ulStudentBikeRegistration">
+                            <li class="menuLv2">
+                                <a id="ctl00_lnkStudentBikeRegistration" onclick="showDialog( &#39;/Titech/Student/PID6_0.aspx&#39;, 1380, 950, &#39;&#39; ); return false;" href="PID6_0.aspx" target="_blank">自転車・オートバイ利用登録</a>
+                            </li>
+                        </ul>
+
+                        
+                        <ul>
+                            <li class="menuLv2">
+                                <a id="ctl00_lnkInquiry" onclick="showDialog( &#39;/Titech/Inquiry.aspx&#39;, 750, 800, &#39;&#39; ); return false;" href="../Inquiry.aspx" target="_blank">お問い合わせ先</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </td>
+
+            <td valign="top" width="90%" id="MainContents">
+                <div id="ctl00_divMainContents" class="mainContents">
+                    
+                    <div id="ctl00_Div1" class="alertMsg" style="text-align: center; margin-top: -10px; margin-bottom: 8px">
+                    </div>
+                    <div id="ctl00_lblStatusAlert" class="alertMsg" style="text-align: center; margin-top: -10px; margin-bottom: 8px">
+                    </div>
+                    <span id="ctl00_lblMessage" class="alertMsg"></span>
+                    <noscript><div class="alertMsg">JavaScriptが有効ではありません。<BR>教務WebシステムはJavaScript対応のブラウザで閲覧してください。</div></noscript>
+                    
+    <style type="text/css">
+        .torikesiPDF {
+            color: #ff4400;
+        }
+    </style>
+
+    <script type="text/javascript">
+
+        $(document).ready(function () {
+            setTimeout(function () {
+                showNewsList();
+            }, 500);
+            setTimeout(function () {
+                showEnqueteList();
+            }, 500);
+
+            
+            setTimeout(function () {
+                showTEList();
+            }, 500);
+            
+
+            $(document).on("click", "a.lnkInput", function () {
+                var jwc = $(this).attr("jwc");
+                showTEInput(query = jwc ? "jwc=" + jwc : "aid=" + $(this).attr("aId"));
+                return false;
+            });
+            
+            
+            $(".spanKyuko").hide();
+            $.ajax({
+                url: "../Common/Service3.ashx?type=kyuko&gno=20B20000",
+                dataType: "text",
+                cache: false,
+                success: function (data) { 
+                    if (data) {
+                        console.log(data);
+                        $("#lblKyuukou").html(data);
+                        $(".spanKyuko").show();
+                    }
+                },
+                error: function () {
+                    $("#lblKyuukou").html("");
+                }
+            });
+            
+        });
+
+        function showNewsList() {
+            $.ajax({
+                url: "../Common/お知らせ/NewsList.aspx",
+                dataType: "text",
+                cache: false,
+                success: function (data) {
+                    if (data) {
+                        $("#divOsirase").html($(data).find("#divOsiraseI").eq(0));
+                        
+                        var id = $("#hdnOsiraseID2").val();
+                        if(id)
+                        {
+                            location.href = "../Common/お知らせ/NewsPopup.aspx?pop=false&id=" + id;
+                            return;
+                        }
+
+                        if($("#hdnOsiraseID").val()) {
+                            setTimeout(function(){ $("#pnlNews").dialog({
+                                autoOpen: false,
+                                modal: true,
+                                minWidth: 800
+                            }).dialog( "open" ); },50);
+                        }
+                        //var sc = $(data).find("script");
+                        //eval(sc.eq(sc.length - 1).html());
+                        //eval("setTimeout(function(){ $('#pnlNews').dialog({    autoOpen: false,    modal: true,    minWidth: 800}).dialog( 'open' ); },50);");
+                        //eval("setTimeout(function() { alert(''); }, 50);");
+                    }
+                },
+                error: function () {
+                    //$("#divTE").hide();
+                    $("#divOsirase").html("");
+                }
+            });
+        }
+
+        function showEnqueteList() {
+            $.ajax({
+                url: "../Common/アンケート/EnqueteList.aspx",
+                dataType: "text",
+                cache: false,
+                success: function (data) {
+                    if (data) {
+                        $("#divEnquete").html($(data).find("#divEnqueteI").eq(0));
+                        
+                        var url = $("#hdnEnqueteUrl").val();
+                        if(url)
+                        {
+                            location.href = url;
+                            return;
+                        }
+                    }
+                },
+                error: function () {
+                    $("#divEnquete").html("");
+                }
+            });
+        }
+
+        function showTEInput(query) {
+            if (!query) {
+                query = "jwc=" + $("#drpJwc").val();
+            }
+            showDialog("../Common/旅費/PID_travel_expenses_input.aspx?" + query, 1200, 1000);
+        }
+
+        function showTEList() {
+            $.ajax({
+                url: "旅費/PID_travel_expenses_top.aspx",
+                dataType: "text",
+                cache: false,
+                success: function (data) { 
+                    if (data) {
+                        $("#divTE").html($(data).find("#div0").eq(0));
+                    }
+                },
+                error: function () {
+                    //$("#divTE").hide();
+                    $("#divTE").html("");
+                }
+            });
+        }
+    </script>
+
+    
+    
+    <div>
+        <div style="float: left">
+            <h3>
+                お知らせ</h3>
+            
+            <div style="margin-bottom: 30px; min-height: 30px;" id="divOsirase">
+                <img src="../img/loading2.gif" border="0" />
+            </div>
+        </div>
+        <div style="float: left; padding-left: 15px">
+            
+<style type="text/css">
+ul.mainte li
+{
+    margin-top: 3px;
+    border-bottom: dotted 1px #bbb;
+    font-weight: normal;
+}
+</style>
+
+<h3>メンテナンス情報</h3>
+<div style="padding:5px;width:270px;background-color: ghostWhite;border:dotted 1px #569;">
+    <span class="comment">下記期間中はログインできません。</span>
+    <div><!-- 直近3つのメンテナンス予定を表示する。 -->
+    <ul style="padding:3px;list-style:none;" class="mainte">
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T1"><b>2022/9/2(金) 4:00</b> ～ <b>8:50</b></span></li>
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T2"><b>2022/9/6(火) 4:00</b> ～ <b>8:50</b></span></li>
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T3"><b>2022/9/9(金) 4:00</b> ～ <b>8:50</b></span></li>
+    </ul>
+    </div>
+    <!-- メンテナンス情報フリーコメント -->
+    <div style="border:solid 1px #568;background-color:White;padding:5px;margin-top:3px;">
+    <textarea name="ctl00$ContentPlaceHolder1$ucMpre$txtMntFree" rows="2" cols="20" readonly="readonly" id="ctl00_ContentPlaceHolder1_ucMpre_txtMntFree">
+毎週火曜日・金曜日の4:00-8:50でメンテナンスを行います。</textarea>
+    </div>
+</div>
+        </div>
+        <br style="clear: both" />
+    </div>
+    <div>
+        
+        <div id="divEnquete">
+            <h3>
+        アンケート</h3>
+            <div style="padding-bottom: 20px"><img src="../img/loading2.gif" border="0" /></div>
+        </div>
+    </div>
+    
+    
+    <h3>旅費支援申請
+    </h3>
+    <div style="margin-bottom: 30px; min-height: 30px;" id="divTE">
+        <img src="../img/loading2.gif" border="0" />
+    </div>
+    
+
+    <div></div>
+    <div class="linkBoxLeft">
+        
+        <div id="ctl00_ContentPlaceHolder1_divShinkoku">
+            <h3 id="ctl00_ContentPlaceHolder1_divShinkokuH3">
+                
+                申告科目の参照</h3>
+            
+            <ul style="margin-bottom: 20px">
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentShinkoku1">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink37" href="../Student/%e7%a7%91%e7%9b%ae%e7%94%b3%e5%91%8a/PID1_0.aspx">時間割から</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentShinkoku2">
+                    <a id="ctl00_ContentPlaceHolder1_lnkKamokuKbn" href="%E7%A7%91%E7%9B%AE%E7%94%B3%E5%91%8A/PID1_1.aspx">科目から</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentCheckResult">
+                    <a id="ctl00_ContentPlaceHolder1_lnkCheckResult" onclick="showDialog( &#39;/Titech/Student/科目申告/PID1_3_1.aspx&#39;, 1400, 900, &#39;&#39; ); return false;" href="../Student/%e7%a7%91%e7%9b%ae%e7%94%b3%e5%91%8a/PID1_3_1.aspx" target="_blank">申告チェック結果/
+過去分の参照</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkBunkeiKyouyou2Outer">
+                    <a id="ctl00_ContentPlaceHolder1_lnkBunkeiKyouyou2" onclick="showDialog( &#39;/Titech/Common/学習申告/PID8_1.aspx&#39;, 500, 500, &#39;&#39; ); return false;" href="../Common/%e5%ad%a6%e7%bf%92%e7%94%b3%e5%91%8a/PID8_1.aspx" target="_blank">文系教養科目履修予約結果</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkBunkeiKyouyouOuter">
+                    <a id="ctl00_ContentPlaceHolder1_lnkBunkeiKyouyou" onclick="showDialog( &#39;/Titech/Common/学習申告/PID8_0.aspx&#39;, 1000, 800, &#39;&#39; ); return false;" href="../Common/%e5%ad%a6%e7%bf%92%e7%94%b3%e5%91%8a/PID8_0.aspx" target="_blank">文系教養科目申告状況</a></li>
+            </ul>
+        </div>
+        
+        <div id="ctl00_ContentPlaceHolder1_divTeisei">
+            <h3>
+                追加申告／申告取消</h3>
+            <ul style="margin-bottom: 20px">
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentTuika">
+                    <a id="ctl00_ContentPlaceHolder1_lnkTeisei" href="../Student/%e6%89%bf%e8%aa%8d%e7%94%b3%e8%ab%8b/PID1_7.aspx">追加申告</a></li>
+                
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentTorikesi">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink4" href="../Student/%e6%89%bf%e8%aa%8d%e7%94%b3%e8%ab%8b/PID1_7.aspx?remove=true">申告取消</a></li>
+            </ul>
+        </div>
+        <div id="ctl00_ContentPlaceHolder1_divSinkokuLink">
+            <h3>
+                申告関係リンク</h3>
+            <ul style="line-height: 200%;">
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink23" href="http://www.titech.ac.jp/enrolled/life/resources/index.html" target="_blank">学修案内</a></li>
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink54" href="http://www.ocw.titech.ac.jp/" target="_blank">ＯＣＷ（シラバス参照）</a></li>
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink38" href="http://www.titech.ac.jp/enrolled/life/undergraduate_timetables.html" target="_blank">時間割PDF(学士課程)</a></li>
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink53" href="http://www.titech.ac.jp/enrolled/life/graduate_timetables.html" target="_blank">時間割PDF(大学院)</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="linkBoxRight">
+        <div id="ctl00_ContentPlaceHolder1_divKyuukou">
+            <h3>
+                各種情報</h3>
+            <ul style="margin-bottom: 20px">
+                
+                <li>
+                    <a id="ctl00_ContentPlaceHolder1_lnkKyuukou" onclick="showDialog( &#39;/Titech/Student/PID5_0.aspx?mode=3&#39;, 1000, 900, &#39;&#39; ); return false;" href="../Student/PID5_0.aspx?mode=3" target="_blank">休講一覧</a>
+                    <span id="ctl00_ContentPlaceHolder1_spanKyuukouCount" class="spanKyuko">&nbsp;&nbsp;&nbsp;&nbsp;今週の休講：
+                        <span id="lblKyuukou"><b><font size="3"></font></b></span></span> </li>
+                
+                <li>
+                    <a href="http://www.titech.ac.jp/staff/rooms/procedures.html" target="_blank">手続書類一覧</a>
+                </li>
+                <li>
+                    <a href="http://www.titech.ac.jp/registrar/index.html" target="_blank">教務課</a>
+                </li>
+                <li>
+                    <a href="http://www.titech.ac.jp/enrolled/board/index.html" target="_blank">学務部掲示物情報</a>
+                </li>
+            </ul>
+        </div>
+        <div id="ctl00_ContentPlaceHolder1_divSeiseki">
+            <h3>
+                成績閲覧</h3>
+            <ul>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSeiseki1G">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink39" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_0.aspx">成績一覧</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSeisekiGPAG">
+                    <a id="ctl00_ContentPlaceHolder1_lnkGPA" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_7.aspx">GPA・GPT</a></li>
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSeiseki2G">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink40" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_1.aspx">修得時期別成績一覧</a></li>
+                
+                
+                
+                
+                
+                
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSenmonYouken">
+                    <a id="ctl00_ContentPlaceHolder1_lnkYouken" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_6.aspx">学士特定課題研究申請・卒業要件</a>
+                </li>
+                <li id="ctl00_ContentPlaceHolder1_lnkMinitukeruChikara">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink188" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_9.aspx">学生が身に付ける力</a></li>
+                
+                
+                
+                <li id="ctl00_ContentPlaceHolder1_lnkStudentSeisekiMihoukoku">
+                    <a id="ctl00_ContentPlaceHolder1_HyperLink2" href="../Student/%e6%88%90%e7%b8%be%e9%96%b2%e8%a6%a7/PID2_3.aspx">成績未報告科目一覧</a></li>
+            </ul>
+            <br />
+            
+            
+        </div>
+    </div>
+    <br />
+    <div style="clear: both">
+        <br />
+        <br />
+        <br />
+        <br />
+        
+        
+        
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        
+    </div>
+
+    
+                </div>
+                <span style="visibility: hidden;">
+                    <input type="submit" name="ctl00$btnDummy" value="" id="ctl00_btnDummy" />
+                </span>
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" valign="top" bgcolor="#000000">
+                <div class="footer" style="clear: both;">
+                    
+                    <span style="color: #005396;">
+                        003</span>
+                    <span style="color: #005396; margin-left: 20px">
+                        Build:2022/08/31 9:02:39</span>
+                </div>
+            </td>
+        </tr>
+    </table>
+        
+    <style type="text/css">
+        #defaultButton {
+            height: 16px;
+        }
+        #divMenu ul:hover
+        {
+            /*background-color: rgba(255,255,255,0.5);*/
+            background-color: rgba(0,0,0,0.05);
+        }
+
+        #pnlMenu {
+            position: fixed;
+            top: 10px;
+        }
+
+        .sideMenu .glyphicon {
+            margin-left: 8px;
+            opacity: 0.8;
+        }
+        
+        
+    </style>
+
+    
+
+        
+    <div class="modal fade" id="modal-menu" tabindex="-1">
+        <div class="modal-dialog" style="width:initial; margin: 5px;">
+            <!-- モーダルのコンテンツ modal fade modalCenter-->
+            <div class="modal-content" style="position: fixed;  overflow-y: scroll; ">
+                <!-- モーダルのボディ -->
+                <div class="modal-body tableSet01" id="menu2" style="padding: 14px">
+                </div>
+                <div id="menu3" style="margin: 4px 14px 24px 14px;    padding: 5px;    border: dotted 1px #060691;    background-color: #f5f5f5;    line-height: 160%;">
+                </div>
+            </div>
+        </div>
+    </div>
+    </form>
+    <script type="text/javascript">
+        
+    </script>
+</body>
+</html>

--- a/Tests/TitechKyomuKitTests/HTML/TopMaintenance.html
+++ b/Tests/TitechKyomuKitTests/HTML/TopMaintenance.html
@@ -1,0 +1,106 @@
+
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head id="ctl00_Head1"><meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate, pre-check=0, post-check=0" /><meta http-equiv="Pragma" content="no-cache" /><meta http-equiv="Expires" content="-1" /><meta name="robots" content="noindex" />
+    <link href="https://ajax.aspnetcdn.com/ajax/jquery.ui/1.11.1/themes/redmond/jquery-ui.css" rel="stylesheet" />
+    <script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.11.2.min.js" ></script>
+    <script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jquery.ui/1.11.3/jquery-ui.min.js" ></script>
+<link href="App_Themes/Default/base.css" type="text/css" rel="stylesheet" /><link href="App_Themes/Default/base2.css" type="text/css" rel="stylesheet" /><link href="App_Themes/Default/base3.css" type="text/css" rel="stylesheet" /><link href="App_Themes/Default/jquery.contextMenu.css" type="text/css" rel="stylesheet" /><link href="App_Themes/Default/popUp.css" type="text/css" rel="stylesheet" /><link href="App_Themes/Default/print.css" type="text/css" rel="stylesheet" /><link href="App_Themes/Default/StyleSheet.css" type="text/css" rel="stylesheet" /><title>
+	教務Webシステム
+</title></head>
+<body class="body">
+    <form name="aspnetForm" method="post" action="./Maintenance.aspx" id="aspnetForm" class="stage">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUJNzExNzcxNzAwD2QWAmYPZBYCAgMPZBYMAgEPDxYEHg1PbkNsaWVudENsaWNrZR4HVmlzaWJsZWhkZAICDw8WAh8AZWRkAgMPDxYCHwFoZGQCBA9kFgICAQ8PFgIfAWgWAh4Hb25jbGljawXvAWlmKCAhY29uZmlybSgn44Ot44Kw44Ki44Km44OI44KS44GX44G+44GZ44CCXG5cbk9L44KS44Kv44Oq44OD44Kv44GZ44KL44Go44Ot44Kw44Ki44Km44OI44GM5a6f6KGM44GV44KMXG7lrablhoXjg53jg7zjgr/jg6vjgbjpgbfnp7vjgZfjgb7jgZnjgIJcbuS4reaWreOBmeOCi+WgtOWQiOOBr+OAjOOCreODo+ODs+OCu+ODq+OAjeOCkuOCr+ODquODg+OCr+OBl+OBpuOBj+OBoOOBleOBhCcpIClyZXR1cm4gZmFsc2U7ZAIGDxYCHglpbm5lcmh0bWxlZAIHD2QWBgIBDxYCHwFoZAIDD2QWCAIFDxYCHwMFKTxiPjIwMjIvOS8yKOmHkSkgNDowMDwvYj4g772eIDxiPjg6NTA8L2I+ZAIHDxYCHwMFKTxiPjIwMjIvOS82KOeBqykgNDowMDwvYj4g772eIDxiPjg6NTA8L2I+ZAIJDxYCHwMFKTxiPjIwMjIvOS85KOmHkSkgNDowMDwvYj4g772eIDxiPjg6NTA8L2I+ZAILDw8WAh4EVGV4dAVO5q+O6YCx54Gr5puc5pel44O76YeR5puc5pel44GuNDowMC04OjUw44Gn44Oh44Oz44OG44OK44Oz44K544KS6KGM44GE44G+44GZ44CCZGQCBQ8PFgIeC05hdmlnYXRlVXJsBTtodHRwczovL3BvcnRhbC5uYXAuZ3NpYy50aXRlY2guYWMuanAvR2V0QWNjZXNzL1Jlc291cmNlTGlzdGRkZFiYALilUO8bj+eqsHtob/NmcGtl" />
+
+<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="3255E3D9" />
+<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEdAAQ8qM0QAOr+6sfK3i4HCDALfWTjPRLcMlc9d2cDJ2JRi3g2JCPx5gAZ8WI3GLHhg5iKsKjzlAcn0r1kDlVqMal1nxkq2DHIv8R4lVoIVJaweXHiMKQ=" />
+    <div class="headerPopup hideAtPrint">
+        <div class="logo left">
+            <a id="top" name="top" href='/Titech/Maintenance.aspx''>
+                <img id="ctl00_imgLogo" src="img/header_img02.jpg" alt="国立大学法人 東京工業大学" border="0" />
+            </a>
+        </div>
+        <div class="right topButton">
+            <div style="padding-top:3px; margin-right:10px;"><span>
+                                
+                                <a id="ctl00_ToEnglish" href="javascript:__doPostBack(&#39;ctl00$ToEnglish&#39;,&#39;&#39;)">English</a>
+                            </span>&nbsp;
+                            &nbsp; 
+                <span id="ctl00_lnkLogout" class="lnkLogout">
+                    
+                </span>
+            </div>
+        </div>
+    </div>
+    <div class="clearfix"/>
+    <div class="mainContents" id="MainContents" style="padding-top: 0px; padding-bottom: 20px;">
+        <div style="visibility: hidden; height:0px; margin-bottom:10px" class="hideAtPrint">
+            <input type="submit" name="ctl00$defaultButton" value="" onclick="return false;" id="ctl00_defaultButton" />
+        </div>
+        <div id="shrinkPreventOuter" class="clearfix">
+            <div id="shrinkPreventInner">
+            </div>
+        </div>
+        <span id="ctl00_lblMessage" class="alertMsg"></span>
+        
+    <div class="tableSet02 clearfix">
+        <div>
+
+            <span id="ctl00_ContentPlaceHolder1_lblContent" style="font-size: large">
+                <b>ただいまメンテナンス中です</b><br />
+                
+            </span>
+        </div>
+        <br />
+        <div style="width: 260px">
+            
+<style type="text/css">
+ul.mainte li
+{
+    margin-top: 3px;
+    border-bottom: dotted 1px #bbb;
+    font-weight: normal;
+}
+</style>
+
+<h3>メンテナンス情報</h3>
+<div style="padding:5px;width:270px;background-color: ghostWhite;border:dotted 1px #569;">
+    <span class="comment">下記期間中はログインできません。</span>
+    <div><!-- 直近3つのメンテナンス予定を表示する。 -->
+    <ul style="padding:3px;list-style:none;" class="mainte">
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T1"><b>2022/9/2(金) 4:00</b> ～ <b>8:50</b></span></li>
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T2"><b>2022/9/6(火) 4:00</b> ～ <b>8:50</b></span></li>
+        <li><span id="ctl00_ContentPlaceHolder1_ucMpre_T3"><b>2022/9/9(金) 4:00</b> ～ <b>8:50</b></span></li>
+    </ul>
+    </div>
+    <!-- メンテナンス情報フリーコメント -->
+    <div style="border:solid 1px #568;background-color:White;padding:5px;margin-top:3px;">
+    <textarea name="ctl00$ContentPlaceHolder1$ucMpre$txtMntFree" rows="2" cols="20" readonly="readonly" id="ctl00_ContentPlaceHolder1_ucMpre_txtMntFree">
+毎週火曜日・金曜日の4:00-8:50でメンテナンスを行います。</textarea>
+    </div>
+</div>
+        </div>
+        <br />
+        <br />
+        <br />
+        <a id="ctl00_ContentPlaceHolder1_lnkPortal" href="https://portal.nap.gsic.titech.ac.jp/GetAccess/ResourceList">Portal</a>
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+
+    </div>
+    <div class="footer">
+        <div>
+        
+                    <span id="spanServerName" style="color: #005396">003</span>
+                    
+            </div>
+    </div>
+    </form>
+</body>
+</html>

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
@@ -2,14 +2,22 @@ import XCTest
 @testable import TitechKyomuKit
 
 final class TitechKyomuKitTests: XCTestCase {
-    func testParseTopPage() async throws {
+    func testParseTopPageJa() async throws {
         let titechkyomu = TitechKyomu(urlSession: .shared)
         let htmlJa = try! String(contentsOf: Bundle.module.url(forResource: "TopJapanese", withExtension: "html")!)
         let resultJa = try await titechkyomu.parseTopPage(html: htmlJa)
         XCTAssertTrue(resultJa)
+    }
+    
+    func testParseTopPageEn() async throws {
+        let titechkyomu = TitechKyomu(urlSession: .shared)
         let htmlEn = try! String(contentsOf: Bundle.module.url(forResource: "TopEnglish", withExtension: "html")!)
         let resultEn = try await titechkyomu.parseTopPage(html: htmlEn)
         XCTAssertTrue(resultEn)
+    }
+    
+    func testParseTopPageMaintenance() async throws {
+        let titechkyomu = TitechKyomu(urlSession: .shared)
         let htmlMaintenance = try! String(contentsOf: Bundle.module.url(forResource: "TopMaintenance", withExtension: "html")!)
         let resultMaintenance = try await titechkyomu.parseTopPage(html: htmlMaintenance)
         XCTAssertFalse(resultMaintenance)

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
@@ -21,4 +21,21 @@ final class TitechKyomuKitTests: XCTestCase {
         XCTAssertFalse(resultEn.contains(KyomuCourse(name: "Solid State Physics (Lattice)", periods: [KyomuCoursePeriod(day: .monday, start: 3, end: 4, location: "S8-102"), KyomuCoursePeriod(day: .thursday, start: 3, end: 4, location: "S8-102")], quarters: [1], code: "MAT.P301")))
         XCTAssertEqual(resultEn[6], KyomuCourse(name: "Introduction to Algorithms and Data Structures", periods: [], quarters: [2], code: "MCS.T213"))
     }
+    
+    func testLogin() async throws {
+        let titechkyomu = TitechKyomu(urlSession: .shared)
+        let cookies: [HTTPCookie] = [
+            HTTPCookie(
+                properties: [
+                    .name: "AUTH_SESSION_ID",
+                    .domain: "https://titech.ac.jp",
+                    .path: "/",
+                    .value: ""
+                ]
+            )!
+        ]
+        URLSession.shared.configuration.httpCookieStorage?.setCookies(cookies, for: URL(string: "https://\(BaseURL.origin)")!, mainDocumentURL: nil)
+        let result = try await titechkyomu.loginToTop()
+        XCTAssertTrue(result)
+    }
 }

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
@@ -24,18 +24,17 @@ final class TitechKyomuKitTests: XCTestCase {
     
     func testLogin() async throws {
         let titechkyomu = TitechKyomu(urlSession: .shared)
-        let cookies: [HTTPCookie] = [
-            HTTPCookie(
-                properties: [
-                    .name: "AUTH_SESSION_ID",
-                    .domain: "https://titech.ac.jp",
-                    .path: "/",
-                    .value: ""
-                ]
-            )!
-        ]
-        URLSession.shared.configuration.httpCookieStorage?.setCookies(cookies, for: URL(string: "https://\(BaseURL.origin)")!, mainDocumentURL: nil)
-        let result = try await titechkyomu.loginToTop()
-        XCTAssertTrue(result)
+        let authSessionId = ""
+        let cookie = HTTPCookie(
+            properties: [
+                .name: "AUTH_SESSION_ID",
+                .domain: ".titech.ac.jp",
+                .path: "/",
+                .value: authSessionId
+            ]
+        )!
+        HTTPCookieStorage.shared.setCookie(cookie)
+        let resultLogin = try await titechkyomu.loginToTop()
+        print(resultLogin)
     }
 }

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
@@ -36,5 +36,7 @@ final class TitechKyomuKitTests: XCTestCase {
         HTTPCookieStorage.shared.setCookie(cookie)
         let resultLogin = try await titechkyomu.loginToTop()
         print(resultLogin)
+        let resultFetch = try await titechkyomu.fetchKyomuCourseData()
+        print(resultFetch)
     }
 }

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
@@ -2,6 +2,19 @@ import XCTest
 @testable import TitechKyomuKit
 
 final class TitechKyomuKitTests: XCTestCase {
+    func testParseTopPage() async throws {
+        let titechkyomu = TitechKyomu(urlSession: .shared)
+        let htmlJa = try! String(contentsOf: Bundle.module.url(forResource: "TopJapanese", withExtension: "html")!)
+        let resultJa = try await titechkyomu.parseTopPage(html: htmlJa)
+        XCTAssertTrue(resultJa)
+        let htmlEn = try! String(contentsOf: Bundle.module.url(forResource: "TopEnglish", withExtension: "html")!)
+        let resultEn = try await titechkyomu.parseTopPage(html: htmlEn)
+        XCTAssertTrue(resultEn)
+        let htmlMaintenance = try! String(contentsOf: Bundle.module.url(forResource: "TopMaintenance", withExtension: "html")!)
+        let resultMaintenance = try await titechkyomu.parseTopPage(html: htmlMaintenance)
+        XCTAssertFalse(resultMaintenance)
+    }
+    
     func testParseReportCheckPageJa() async throws {
         let titechkyomu = TitechKyomu(urlSession: .shared)
         let htmlJa = try! String(contentsOf: Bundle.module.url(forResource: "ReportCheckResultJapanese", withExtension: "html")!)
@@ -20,23 +33,5 @@ final class TitechKyomuKitTests: XCTestCase {
         XCTAssertEqual(resultEn[0], KyomuCourse(name: "Spectroscopy", periods: [KyomuCoursePeriod(day: .monday, start: 1, end: 2, location: "S7-202"), KyomuCoursePeriod(day: .thursday, start: 1, end: 2, location: "S7-202")], quarters: [1], code: "MAT.C302"))
         XCTAssertFalse(resultEn.contains(KyomuCourse(name: "Solid State Physics (Lattice)", periods: [KyomuCoursePeriod(day: .monday, start: 3, end: 4, location: "S8-102"), KyomuCoursePeriod(day: .thursday, start: 3, end: 4, location: "S8-102")], quarters: [1], code: "MAT.P301")))
         XCTAssertEqual(resultEn[6], KyomuCourse(name: "Introduction to Algorithms and Data Structures", periods: [], quarters: [2], code: "MCS.T213"))
-    }
-    
-    func testLogin() async throws {
-        let titechkyomu = TitechKyomu(urlSession: .shared)
-        let authSessionId = ""
-        let cookie = HTTPCookie(
-            properties: [
-                .name: "AUTH_SESSION_ID",
-                .domain: ".titech.ac.jp",
-                .path: "/",
-                .value: authSessionId
-            ]
-        )!
-        HTTPCookieStorage.shared.setCookie(cookie)
-        let resultLogin = try await titechkyomu.loginToTop()
-        print(resultLogin)
-        let resultFetch = try await titechkyomu.fetchKyomuCourseData()
-        print(resultFetch)
     }
 }

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTestsOnProduction.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTestsOnProduction.swift
@@ -2,16 +2,17 @@ import XCTest
 @testable import TitechKyomuKit
 
 final class TitechKyomuKitTestsOnProduction: XCTestCase {
-    let cookie = HTTPCookie(
-        properties: [
-            .name: "AUTH_SESSION_ID",
-            .domain: ".titech.ac.jp",
-            .path: "/",
-            .value: ""  // use actual AUTH_SESSION_ID value
-        ]
-    )!
     // To try on production environment, uncomment the following:
     
+//    let cookie = HTTPCookie(
+//        properties: [
+//            .name: "AUTH_SESSION_ID",
+//            .domain: ".titech.ac.jp",
+//            .path: "/",
+//            .value: ""  // use actual AUTH_SESSION_ID value
+//        ]
+//    )!
+//
 //    func testLoginOnProduction() async throws {
 //        let titechkyomu = TitechKyomu(urlSession: .shared)
 //        HTTPCookieStorage.shared.setCookie(cookie)

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTestsOnProduction.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTestsOnProduction.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import TitechKyomuKit
+
+final class TitechKyomuKitTestsOnProduction: XCTestCase {
+    let cookie = HTTPCookie(
+        properties: [
+            .name: "AUTH_SESSION_ID",
+            .domain: ".titech.ac.jp",
+            .path: "/",
+            .value: ""  // use actual AUTH_SESSION_ID value
+        ]
+    )!
+    // To try on production environment, uncomment the following:
+    
+//    func testLoginOnProduction() async throws {
+//        let titechkyomu = TitechKyomu(urlSession: .shared)
+//        HTTPCookieStorage.shared.setCookie(cookie)
+//        let resultLogin = try await titechkyomu.fetchTopPage()
+//        XCTAssertTrue(resultLogin)
+//    }
+//
+//    func testParseReportCheckPageJaOnProduction() async throws {
+//        let titechkyomu = TitechKyomu(urlSession: .shared)
+//        HTTPCookieStorage.shared.setCookie(cookie)
+//        let resultLogin = try await titechkyomu.fetchTopPage()
+//        XCTAssertTrue(resultLogin)
+//        if let cookies = HTTPCookieStorage.shared.cookies {
+//            for cookie in cookies {
+//                if (cookie.name == "Language" && cookie.value == "en-US") {
+//                    HTTPCookieStorage.shared.deleteCookie(cookie)
+//                    let cookieJa = HTTPCookie(
+//                        properties: [
+//                            .name: "Language",
+//                            .domain: "kyomu2.gakumu.titech.ac.jp",
+//                            .path: "/",
+//                            .value: "ja-JP"
+//                        ]
+//                    )!
+//                    HTTPCookieStorage.shared.setCookie(cookieJa)
+//                }
+//            }
+//        }
+//        let resultJa = try await titechkyomu.fetchKyomuCourseData()
+//        XCTAssertEqual(resultJa[0], KyomuCourse(name: "分光学", periods: [KyomuCoursePeriod(day: .monday, start: 1, end: 2, location: "S7-202"), KyomuCoursePeriod(day: .thursday, start: 1, end: 2, location: "S7-202")], quarters: [1], code: "MAT.C302"))
+//        XCTAssertTrue(resultJa.contains(KyomuCourse(name: "固体物理学(格子系)", periods: [KyomuCoursePeriod(day: .monday, start: 3, end: 4, location: "S8-102"), KyomuCoursePeriod(day: .thursday, start: 3, end: 4, location: "S8-102")], quarters: [1], code: "MAT.P301")))
+//        XCTAssertFalse(resultJa.contains(KyomuCourse(name: "架空の科目", periods: [KyomuCoursePeriod(day: .monday, start: 3, end: 4, location: "S8-102"), KyomuCoursePeriod(day: .thursday, start: 3, end: 4, location: "S8-102")], quarters: [1], code: "MAT.P301")))
+//        XCTAssertEqual(resultJa[7], KyomuCourse(name: "アルゴリズムとデータ構造", periods: [], quarters: [2], code: "MCS.T213"))
+//    }
+//
+//    func testParseReportCheckPageEnOnProduction() async throws {
+//        let titechkyomu = TitechKyomu(urlSession: .shared)
+//        HTTPCookieStorage.shared.setCookie(cookie)
+//        let resultLogin = try await titechkyomu.fetchTopPage()
+//        XCTAssertTrue(resultLogin)
+//        if let cookies = HTTPCookieStorage.shared.cookies {
+//            for cookie in cookies {
+//                if (cookie.name == "Language" && cookie.value == "ja-JP") {
+//                    HTTPCookieStorage.shared.deleteCookie(cookie)
+//                    let cookieEn = HTTPCookie(
+//                        properties: [
+//                            .name: "Language",
+//                            .domain: "kyomu2.gakumu.titech.ac.jp",
+//                            .path: "/",
+//                            .value: "en-US"
+//                        ]
+//                    )!
+//                    HTTPCookieStorage.shared.setCookie(cookieEn)
+//                }
+//            }
+//        }
+//        let resultEn = try await titechkyomu.fetchKyomuCourseData()
+//        print(resultEn)
+//        XCTAssertEqual(resultEn[0], KyomuCourse(name: "Spectroscopy", periods: [KyomuCoursePeriod(day: .monday, start: 1, end: 2, location: "S7-202"), KyomuCoursePeriod(day: .thursday, start: 1, end: 2, location: "S7-202")], quarters: [1], code: "MAT.C302"))
+//        XCTAssertTrue(resultEn.contains(KyomuCourse(name: "Solid State Physics (Lattice)", periods: [KyomuCoursePeriod(day: .monday, start: 3, end: 4, location: "S8-102"), KyomuCoursePeriod(day: .thursday, start: 3, end: 4, location: "S8-102")], quarters: [1], code: "MAT.P301")))
+//        XCTAssertFalse(resultEn.contains(KyomuCourse(name: "Course that no longer exists", periods: [KyomuCoursePeriod(day: .monday, start: 3, end: 4, location: "S8-102"), KyomuCoursePeriod(day: .thursday, start: 3, end: 4, location: "S8-102")], quarters: [1], code: "MAT.P301")))
+//        XCTAssertEqual(resultEn[7], KyomuCourse(name: "Introduction to Algorithms and Data Structures", periods: [], quarters: [2], code: "MCS.T213"))
+//    }
+}


### PR DESCRIPTION
ポータルにログインした後、教務Webの `科目申告/PID1_3_1.aspx` に直接アクセスしようとすると、cookie が未設定ゆえリダイレクトされてしまうため、教務Webのトップに一旦アクセスする `TopPageRequest` 及び `fetchTopPage()` 、`parseTopPage()` を作成した。

なお、`parseTopPage()` の返り値のBoolは、Requestで返るHTMLのtitleに `トップ` または `Top` が含まれるかを表し、メンテナンス中はFalseになる。