### PR TITLE
KyomuCourseに年度情報を含めました

### DIFF
--- a/Sources/TitechKyomuKit/Object/KyomuCourse.swift
+++ b/Sources/TitechKyomuKit/Object/KyomuCourse.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct KyomuCourse: Equatable, Codable {
     public let name: String
     public let periods: [KyomuCoursePeriod]
+    public let year: Int
     public let quarters: [Int]
     public let code: String
     public let ocwId: String

--- a/Sources/TitechKyomuKit/TitechKyomu.swift
+++ b/Sources/TitechKyomuKit/TitechKyomu.swift
@@ -36,6 +36,11 @@ public struct TitechKyomu {
 
     func parseReportCheckPage(html: String) async throws -> [KyomuCourse] {
         let doc = try HTML(html: html, encoding: .utf8)
+        let title = doc.css("#ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl13_lblTerm")
+            .first?
+            .content?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let year = Int(title.matches(#"^(\d+)"#)?.first?.first ?? "") ?? 0
         
         return doc.css("#ctl00_ContentPlaceHolder1_CheckResult1_grid tr:not(:first-of-type)").compactMap { row -> KyomuCourse? in
             let tds = row.css("td")
@@ -61,6 +66,7 @@ public struct TitechKyomu {
             return KyomuCourse(
                 name: tds[6].css(".showAtPrintDiv").first?.content?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
                 periods: periods,
+                year: year,
                 quarters: KyomuCourse.convert2Quarters(tds[1].content?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""),
                 code: tds[5].content?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
                 ocwId: ocwId ?? "",

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
@@ -34,6 +34,7 @@ final class TitechKyomuKitTests: XCTestCase {
                 name: "分光学",
                 periods: [KyomuCoursePeriod(day: .monday, start: 1, end: 2, location: "S7-202"),
                           KyomuCoursePeriod(day: .thursday, start: 1, end: 2, location: "S7-202")],
+                year: 2022,
                 quarters: [1],
                 code: "MAT.C302",
                 ocwId: "202202171",
@@ -46,6 +47,7 @@ final class TitechKyomuKitTests: XCTestCase {
             KyomuCourse(
                 name: "アルゴリズムとデータ構造",
                 periods: [],
+                year: 2022,
                 quarters: [2],
                 code: "MCS.T213",
                 ocwId: "202202382",
@@ -60,6 +62,7 @@ final class TitechKyomuKitTests: XCTestCase {
                     KyomuCoursePeriod(day: .tuesday, start: 3, end: 4, location: "W931"),
                     KyomuCoursePeriod(day: .friday, start: 3, end: 4, location: "W931")
                 ],
+                year: 2022,
                 quarters: [4],
                 code: "MCS.T419",
                 ocwId: "202217437",
@@ -81,6 +84,7 @@ final class TitechKyomuKitTests: XCTestCase {
                     KyomuCoursePeriod(day: .monday, start: 1, end: 2, location: "S7-202"),
                     KyomuCoursePeriod(day: .thursday, start: 1, end: 2, location: "S7-202")
                 ],
+                year: 2022,
                 quarters: [1],
                 code: "MAT.C302",
                 ocwId: "202202171",
@@ -93,6 +97,7 @@ final class TitechKyomuKitTests: XCTestCase {
             KyomuCourse(
                 name: "Introduction to Algorithms and Data Structures",
                 periods: [],
+                year: 2022,
                 quarters: [2],
                 code: "MCS.T213",
                 ocwId: "202202382",
@@ -107,6 +112,7 @@ final class TitechKyomuKitTests: XCTestCase {
                     KyomuCoursePeriod(day: .tuesday, start: 3, end: 4, location: "W931"),
                     KyomuCoursePeriod(day: .friday, start: 3, end: 4, location: "W931")
                 ],
+                year: 2022,
                 quarters: [4],
                 code: "MCS.T419",
                 ocwId: "202217437",


### PR DESCRIPTION
- 申告チェック結果ページの「2022後学期」などの文字列から年度情報を抽出し、KyomuCourseにその情報を含めました。

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/40226692/203886358-10bffe7b-a9e1-4d4d-8727-248b9dc464d0.png">
