### PR TITLE
講義情報のフィルターするために結果欄を使うように変更しました。

### DIFF
--- a/Sources/TitechKyomuKit/TitechKyomu.swift
+++ b/Sources/TitechKyomuKit/TitechKyomu.swift
@@ -44,8 +44,7 @@ public struct TitechKyomu {
         
         return doc.css("#ctl00_ContentPlaceHolder1_CheckResult1_grid tr:not(:first-of-type)").compactMap { row -> KyomuCourse? in
             let tds = row.css("td")
-            let resultContent = tds[9].content ?? ""
-            guard resultContent.contains("OK") || resultContent.contains("○") else {
+            guard let resultContent = tds[9].content, resultContent.contains("OK") || resultContent.contains("○") else {
                 return nil
             }
 

--- a/Sources/TitechKyomuKit/TitechKyomu.swift
+++ b/Sources/TitechKyomuKit/TitechKyomu.swift
@@ -44,7 +44,8 @@ public struct TitechKyomu {
         
         return doc.css("#ctl00_ContentPlaceHolder1_CheckResult1_grid tr:not(:first-of-type)").compactMap { row -> KyomuCourse? in
             let tds = row.css("td")
-            guard (tds[10].content ?? "").trimmingCharacters(in: .whitespacesAndNewlines) == "OK" else {
+            let resultContent = tds[9].content ?? ""
+            guard resultContent.contains("OK") || resultContent.contains("○") else {
                 return nil
             }
 

--- a/Tests/TitechKyomuKitTests/HTML/ReportCheckResultEnglish.html
+++ b/Tests/TitechKyomuKitTests/HTML/ReportCheckResultEnglish.html
@@ -773,6 +773,43 @@ $(function() {
                     
                     
                 </td>
+        </tr><tr>
+            <td align="center" style="width:70px;">
+                    Undergraduate School
+                </td><td align="center" class="  tdQuarter4" style="width:40px;">
+                    
+                    4Q
+                </td><td style="width:120px;">
+                    Tue3-4 (情報工学系計算機室)<br>Fri3-4 (情報工学系計算機室)
+                </td><td style="width:120px;">Major courses</td><td align="center" style="width:60px;">300</td><td align="left" style="width:100px;">
+                    CSC.T375
+                </td><td style="width:15%;">
+                    <div class="hideAtPrint">
+                        <a id="ctl00_ContentPlaceHolder1_CheckResult1_grid_ctl10_HyperLink1" href="http://www.ocw.titech.ac.jp/index.php?module=General&amp;action=T0300&amp;JWC=202202449&amp;lang=EN&amp;vid=03" target="_blank">Workshop on System Implementation </a>
+                    </div>
+                    <div class="showAtPrintDiv">
+                        Workshop on System Implementation
+                    </div>
+                    
+                    
+                </td><td style="width:12%;">
+                    Ono Shunsuke<br>Tamura Yasumasa
+                </td><td align="center" style="width:40px;white-space:nowrap;">
+                    0-2-0
+                </td><td align="center" style="width:40px;">
+                    OK to register
+                </td><td style="width:80px;">
+                    既修得前提(注意)
+                </td><td style="width:120px;">
+                    You must acquire this Course:    Workshop on System Design
+                </td><td class="minWidth150">
+                    
+                    C(○)<br><span class="red"><span class="red">※履修前提条件付き科目</span></span>
+                    <div>
+                    </div>
+                    
+                    
+                </td>
         </tr>
 	</table>
 </div>

--- a/Tests/TitechKyomuKitTests/HTML/ReportCheckResultJapanese.html
+++ b/Tests/TitechKyomuKitTests/HTML/ReportCheckResultJapanese.html
@@ -775,6 +775,43 @@ $(function() {
                     
                     
                 </td>
+        </tr><tr>
+            <td align="center" style="width:70px;">
+                    学士課程
+                </td><td align="center" class="  tdQuarter4" style="width:40px;">
+                    
+                    4Q
+                </td><td style="width:120px;">
+                    火3-4 (情報工学系計算機室)<br>金3-4 (情報工学系計算機室)
+                </td><td style="width:120px;">専門科目</td><td align="center" style="width:60px;">300</td><td align="left" style="width:100px;">
+                    CSC.T375
+                </td><td style="width:15%;">
+                    <div class="hideAtPrint">
+                        <a id="ctl00_ContentPlaceHolder1_CheckResult1_grid_ctl10_HyperLink1" href="http://www.ocw.titech.ac.jp/index.php?module=General&amp;action=T0300&amp;JWC=202202449&amp;lang=JA&amp;vid=03" target="_blank">システム構築演習 </a>
+                    </div>
+                    <div class="showAtPrintDiv">
+                        システム構築演習
+                    </div>
+                    
+                    
+                </td><td style="width:12%;">
+                    小野 峻佑<br>田村 康将
+                </td><td align="center" style="width:40px;white-space:nowrap;">
+                    0-2-0
+                </td><td align="center" style="width:40px;">
+                    ○
+                </td><td style="width:80px;">
+                    既修得前提(注意)
+                </td><td style="width:120px;">
+                    次の科目の修得が前提です：    システム設計演習
+                </td><td class="minWidth150">
+                    
+                    C(○)<br><span class="red"><span class="red">※履修前提条件付き科目</span></span>
+                    <div>
+                    </div>
+                    
+                    
+                </td>
         </tr>
 	</table>
 </div>

--- a/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
+++ b/Tests/TitechKyomuKitTests/TitechKyomuKitTests.swift
@@ -69,6 +69,21 @@ final class TitechKyomuKitTests: XCTestCase {
                 isForm8: true
             )
         )
+        XCTAssertEqual(
+            resultJa[8],
+            KyomuCourse(
+                name: "システム構築演習",
+                periods: [
+                    KyomuCoursePeriod(day: .tuesday, start: 3, end: 4, location: "情報工学系計算機室"),
+                    KyomuCoursePeriod(day: .friday, start: 3, end: 4, location: "情報工学系計算機室")
+                ],
+                year: 2022,
+                quarters: [4],
+                code: "CSC.T375",
+                ocwId: "202202449",
+                isForm8: false
+            )
+        )
     }
     
     func testParseReportCheckPageEn() async throws {
@@ -119,5 +134,21 @@ final class TitechKyomuKitTests: XCTestCase {
                 isForm8: true
             )
         )
+        XCTAssertEqual(
+            resultEn[8],
+            KyomuCourse(
+                name: "Workshop on System Implementation",
+                periods: [
+                    KyomuCoursePeriod(day: .tuesday, start: 3, end: 4, location: "情報工学系計算機室"),
+                    KyomuCoursePeriod(day: .friday, start: 3, end: 4, location: "情報工学系計算機室")
+                ],
+                year: 2022,
+                quarters: [4],
+                code: "CSC.T375",
+                ocwId: "202202449",
+                isForm8: false
+            )
+        )
+
     }
 }


### PR DESCRIPTION
講義をフィルターするために、従来は `チェック内容` の情報を使っていましたが、 `結果`を使うように変更し、それに伴いテストの追加を行いました。

この変更により、追加申告や既習得前提の科目が表示されない問題が解決されます。