### PR TITLE
HTTP Postの処理を削除

### DIFF
--- a/Sources/TitechKyomuKit/HTTP/HTTPRequest.swift
+++ b/Sources/TitechKyomuKit/HTTP/HTTPRequest.swift
@@ -22,7 +22,6 @@ enum BaseURL {
 
 enum HTTPMethod: String {
     case get = "GET"
-    case post = "POST"
 }
 
 protocol HTTPRequest {
@@ -47,24 +46,6 @@ extension HTTPRequest {
             request.httpMethod = method.rawValue
             request.httpShouldHandleCookies = true
             request.allHTTPHeaderFields = headerFields?.merging(["User-Agent" : userAgent], uniquingKeysWith: { key1, _ in key1}) ?? [:]
-            return request
-        case .post:
-            guard let url = components.url else {
-                fatalError("Could not get url")
-            }
-
-            let allowedCharacterSet = CharacterSet(charactersIn: "!'();:@&=+$,/?%#[]").inverted
-
-            components.queryItems = body?.map {
-                URLQueryItem(name: String($0), value: String($1).addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)?.replacingOccurrences(of: " ", with: "+") ?? "")
-            }
-
-            var request = URLRequest(url: url)
-            request.httpMethod = method.rawValue
-            request.httpShouldHandleCookies = true
-            request.httpBody = (components.query ?? "").data(using: .utf8)
-            request.allHTTPHeaderFields = headerFields?.merging(["User-Agent" : userAgent], uniquingKeysWith: { key1, _ in key1}) ?? [:]
-
             return request
         }
     }

--- a/Sources/TitechKyomuKit/HTTP/HTTPRequest.swift
+++ b/Sources/TitechKyomuKit/HTTP/HTTPRequest.swift
@@ -30,8 +30,6 @@ protocol HTTPRequest {
     var method: HTTPMethod { get }
 
     var headerFields: [String: String]? { get }
-
-    var body: [String: String]? { get }
 }
 
 extension HTTPRequest {

--- a/Sources/TitechKyomuKit/HTTP/ReportCheckPageRequest.swift
+++ b/Sources/TitechKyomuKit/HTTP/ReportCheckPageRequest.swift
@@ -11,6 +11,4 @@ struct ReportCheckPageRequest: HTTPRequest {
         "Accept-Encoding": "br, gzip, deflate",
         "Accept-Language": "ja-jp"
     ]
-    
-    let body: [String : String]? = nil
 }

--- a/Sources/TitechKyomuKit/HTTP/TopPageRequest.swift
+++ b/Sources/TitechKyomuKit/HTTP/TopPageRequest.swift
@@ -11,6 +11,4 @@ struct TopPageRequest: HTTPRequest {
         "Accept-Encoding": "br, gzip, deflate",
         "Accept-Language": "ja-jp"
     ]
-    
-    let body: [String : String]? = nil
 }


### PR DESCRIPTION
## 概要

TitechKyomuKitでは基本的にGETでの情報取得しかしないはずなのでPOST周りの処理を削除させてスッキリさせた。
もし今後追加することになったらリバートする