### PR TITLE
年度表記に当てられた全てのCSSのIDに正規表現で対応

### DIFF
--- a/Sources/TitechKyomuKit/TitechKyomu.swift
+++ b/Sources/TitechKyomuKit/TitechKyomu.swift
@@ -39,9 +39,7 @@ public struct TitechKyomu {
     func parseReportCheckPage(html: String) throws -> [KyomuCourse] {
         let doc = try HTML(html: html, encoding: .utf8)
         let title =
-            doc.css("#ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl00_lblTerm, #ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl13_lblTerm, #ctl00_ContentPlaceHolder1_ctl00_lblTerm")
-            // ...ctl00_lblTerm が2024/10時点、...ctl13_lblTerm が2024/9の東工大時代のCSSのIDです。今後も変更される可能性があります。
-            // #ctl00_ContentPlaceHolder1_ctl00_lblTerm は履修登録状況が一時保存のときのIDです。 今後も変更される可能性があります。
+            doc.css("[id$='_lblTerm']") // 科学大変更前後・一時保存の全ケースに対応
             .first?
             .content?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""


### PR DESCRIPTION
教務Webの申告チェック画面の年度表記に当てられるCSSのIDが
- 東工大時代: ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl13_lblTerm
- 科学大: ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl00_lblTerm
- 科学大で一時保存状態: ctl00_ContentPlaceHolder1_ctl00_lblTerm

といくつか存在していてエラーの原因となっていたが、表示している年度に割り振られるIDは`lblTerm`を末尾に持つことが共通で、ページ内で他にこの単語は出てこないため、検索を
```swift
doc.css("[id$='_lblTerm']")
```
の形に変更した。